### PR TITLE
Some change in Opus Configuration

### DIFF
--- a/src/CSoundInput.cpp
+++ b/src/CSoundInput.cpp
@@ -266,7 +266,7 @@ CSoundInput::CSoundInput(char* deviceName, int sampleRate, int framesPerBuffer, 
 	if (opus_encoder_ctl(enc, OPUS_SET_BITRATE(_bitRate)) != OPUS_OK)
 		EXIT_ON_ERROR(-1, AltVoiceError::OpusBitrateSetError);
 
-	if (opus_encoder_ctl(enc, OPUS_SET_SIGNAL(OPUS_SIGNAL_VOICE)) != OPUS_OK)
+	if (opus_encoder_ctl(enc, OPUS_SET_SIGNAL(OPUS_SIGNAL_AUTO)) != OPUS_OK)
 		EXIT_ON_ERROR(-1, AltVoiceError::OpusSignalSetError);
 
 	opus_encoder_ctl(enc, OPUS_SET_INBAND_FEC(1));

--- a/src/CSoundInput.cpp
+++ b/src/CSoundInput.cpp
@@ -270,7 +270,7 @@ CSoundInput::CSoundInput(char* deviceName, int sampleRate, int framesPerBuffer, 
 		EXIT_ON_ERROR(-1, AltVoiceError::OpusSignalSetError);
 
 	opus_encoder_ctl(enc, OPUS_SET_INBAND_FEC(1));
-	opus_encoder_ctl(enc, OPUS_SET_PACKET_LOSS_PERC(10));
+	opus_encoder_ctl(enc, OPUS_SET_PACKET_LOSS_PERC(15));
 
 	transferBuffer = new Sample[_framesPerBuffer];
 


### PR DESCRIPTION
Like described, i have up SET_PACKET_LOSS_PERC cause alot of people is playing on ADSL/4G.
Also OPUS_SIGNAL_AUTO is usefull for people who use soundbox or share music in-game cause music is actually way too compressed.

If encoder don't handle that correctly we can easily revert.